### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,7 +17,7 @@ terminaltables = "*"
 ordered-set = "*"
 python-dateutil = "*"
 mzo = {editable = true,path = "."}
-fuzzywuzzy = {extras = ["speedup"],version = "*"}
+rapidfuzz = "*"
 idna = "<2.9"  # temp: requests requiring <2.9
 
 [dev-packages]

--- a/mzo/pots.py
+++ b/mzo/pots.py
@@ -4,7 +4,7 @@ import asyncio
 
 import click
 
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 import mzo.utils.authentication
 from mzo.utils.formats import Format

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ REQUIRED = [
     "terminaltables",
     "ordered-set",
     "python-dateutil",
-    "fuzzywuzzy[speedup]",
+    "rapidfuzz",
     "idna<2.9",
 ]
 

--- a/snapcraft-requirements.txt
+++ b/snapcraft-requirements.txt
@@ -9,7 +9,7 @@ certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
 click==7.0
-fuzzywuzzy[speedup]==0.18.0
+rapidfuzz==0.2.2
 h11==0.8.1
 h2==3.2.0
 hpack==3.0.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it faster than FuzzyWuzzy.